### PR TITLE
ci: explicitly set python version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,6 +19,8 @@ jobs:
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.16.5


### PR DESCRIPTION
Set the Python version for GHA explicitly. Otherwise the local python will be used, with varying results on recent builds.