### PR TITLE
Add wheels for macOS

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ 3.9, 3.10, 3.11, 3.12 ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: nmslib_metabrainz-wheels-${{ runner.os }}
-          path: wheelhouse/nmslib*.whl
+          name: nmslib_metabrainz-wheels-macos-${{ matrix.python-version }}
+          path: python_bindings/wheelhouse/nmslib*.whl
 
   build_sdist:
     name: Build source distribution

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,7 @@
 name: Continuous Delivery
 
 on:
+  workflow_dispatch:
   push:
   release:
     types: [published]
@@ -30,7 +31,7 @@ jobs:
         with:
           name: nmslib_metabrainz-wheels-${{ runner.os }}
           path: wheelhouse/*.whl
-  
+
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,8 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019]
-        # os: [ubuntu-20.04, windows-2019, macOS-12]
+        os: [ubuntu-20.04, windows-2019, macos-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,23 +13,53 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-20.04, windows-2019]
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.5
         with:
-          python-version: '3.12'
-
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+          package-dir: python_bindings
+        env:
+          CIBW_SKIP: "*-win32 cp3{6,7,8}-* pp*-* *_i686"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: nmslib_metabrainz-wheels-${{ runner.os }}
           path: wheelhouse/*.whl
+
+  build_wheels_macos:
+    name: Build wheels on macos-latest (Python ${{ matrix.python-version }})
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: [ 3.9, 3.10, 3.11, 3.12 ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build wheels
+        run: |
+          pip3 install -r dev-requirements.txt
+          python3 setup.py build_ext
+          pip3 wheel . -w wheelhouse
+        env:
+          CFLAGS: '-mavx'
+      - name: Test wheels
+        run: |
+          pip3 install nmslib-metabrainz --no-index -f wheelhouse
+          python3 -m pytest tests/bindings_test.py
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nmslib_metabrainz-wheels-${{ runner.os }}
+          path: wheelhouse/nmslib*.whl
 
   build_sdist:
     name: Build source distribution
@@ -47,7 +77,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheels, build_sdist, build_wheels_macos]
     environment:
       name: pypi
       url: https://pypi.org/p/nmslib-metabrainz

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,7 +1,6 @@
 name: Continuous Delivery
 
 on:
-  workflow_dispatch:
   push:
   release:
     types: [published]
@@ -63,7 +62,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: nmslib_metabrainz-wheels-macos-${{ matrix.python-version }}
+          name: nmslib_metabrainz-wheels-macos-python-${{ matrix.python-version }}
           path: python_bindings/wheelhouse/nmslib*.whl
 
   build_sdist:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,9 +40,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Build wheels
         run: |
           pip3 install -r dev-requirements.txt
@@ -50,10 +52,13 @@ jobs:
           pip3 wheel . -w wheelhouse
         env:
           CFLAGS: '-mavx'
+        working-directory: python_bindings
+
       - name: Test wheels
         run: |
           pip3 install nmslib-metabrainz --no-index -f wheelhouse
           python3 -m pytest tests/bindings_test.py
+        working-directory: python_bindings
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,12 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+      - uses: actions/setup-python@v5
         with:
-          package-dir: python_bindings
-        env:
-          CIBW_SKIP: "*-win32 cp3{6,7,8}-* pp*-* *_i686"
+          python-version: '3.12'
 
       - name: Setup upterm session
         uses: lhotari/action-upterm@v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-latest]
+        os: [macos-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +24,9 @@ jobs:
           package-dir: python_bindings
         env:
           CIBW_SKIP: "*-win32 cp3{6,7,8}-* pp*-* *_i686"
+
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
cibuildwheel is unable to build wheels for macOS, use pip directly to build the wheels.