### PR TITLE
Build Python 3.13 wheels

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-22.04, windows-2019]
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.22.0
         with:
           package-dir: python_bindings
         env:
@@ -35,7 +35,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -131,7 +131,8 @@ class BuildExt(build_ext):
 
     if sys.platform == 'darwin':
         if platform.processor() in ('arm64', 'arm'):
-            c_opts['unix'].remove('-march=native')
+            if '-march=native' in c_opts['unix']:
+                c_opts['unix'].remove('-march=native')
             # thanks to @https://github.com/drkeoni
             # https://github.com/nmslib/nmslib/issues/476#issuecomment-876094529
             c_opts['unix'].append('-mcpu=apple-a14')


### PR DESCRIPTION
To support Python 3.13, add 3.13 wheels build.

The result of GH Action can be seen at https://github.com/chezou/nmslib-metabrainz/actions/runs/12290302085